### PR TITLE
homepage: sources upto the end of June 2026

### DIFF
--- a/templates/ar5iv.html.tera
+++ b/templates/ar5iv.html.tera
@@ -36,7 +36,7 @@
               <li style="margin-bottom: 2rem;">Converted from TeX with <a class="ltx_ref"
                   href="https://github.com/brucemiller/LaTeXML">LaTeXML</a>.
               </li>
-              <li style="margin-bottom: 2rem;">Sources upto the end of May 2026.
+              <li style="margin-bottom: 2rem;">Sources upto the end of June 2026.
                 <span class="ltx_font_bold">Not</span> a live preview service.
               </li>
               <li style="margin-bottom: 2rem;">Available as a dataset, <a class="ltx_ref" href="https://sigmathling.kwarc.info/resources/ar5iv-dataset-2024/">download here</a>.


### PR DESCRIPTION
Template date bump for the July-5 corpus update: the homepage now states sources run to the end of **June 2026** (was May 2026), matching the incoming 2606 conversion run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)